### PR TITLE
Feature/docurlcontent

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-反馈.md
+++ b/.github/ISSUE_TEMPLATE/bug-反馈.md
@@ -2,7 +2,7 @@
 name: Bug 反馈
 about: 代码不起作用/抛出异常/结果不正确
 title: "[BUG]"
-labels: bug, untriaged
+labels: enhancement, untriaged
 assignees: ikesnowy
 
 ---

--- a/.github/ISSUE_TEMPLATE/sdk-相关.md
+++ b/.github/ISSUE_TEMPLATE/sdk-相关.md
@@ -1,0 +1,24 @@
+---
+name: SDK 相关
+about: SDK 本身的改进，例如升级依赖包版本/添加方法重载/提供额外能力等
+title: "[SDK] "
+labels: ".NET, untriaged"
+assignees: ikesnowy
+
+---
+
+**希望更改的 SDK 内容**
+
+受影响的 SDK API
+```csharp
+// 提供 SDK 的方法名或者调用方法
+```
+
+希望做出的改进
+```csharp
+// 希望以这种方式调用
+```
+
+**其他信息**
+
+使用场景/项目背景/限制条件（例如：无法依赖 xx 包），以及可接受的其他方式

--- a/src/Cnblogs.DashScope.AI/DashScopeChatClient.cs
+++ b/src/Cnblogs.DashScope.AI/DashScopeChatClient.cs
@@ -420,10 +420,19 @@ public sealed class DashScopeChatClient : IChatClient
     {
         if (from.Role == ChatRole.System || from.Role == ChatRole.User)
         {
-            yield return new TextChatMessage(
-                from.Role.Value,
-                from.Text,
-                from.AuthorName);
+            if (from.Contents.Any() && from.Contents.Any(d => d is TextContent) && from.Contents.Any(d => d is DocUrlContent))
+            {
+                yield return TextChatMessage.DocUrl(
+                    ((from.Contents.FirstOrDefault(c => c is TextContent) as TextContent)!).Text,
+                    (from.Contents.FirstOrDefault(d => d is DocUrlContent) as DocUrlContent)!.DocUrl);
+            }
+            else
+            {
+                yield return new TextChatMessage(
+                    from.Role.Value,
+                    from.Text,
+                    from.AuthorName);
+            }
         }
         else if (from.Role == ChatRole.Tool)
         {

--- a/src/Cnblogs.DashScope.AI/DocUrlContent.cs
+++ b/src/Cnblogs.DashScope.AI/DocUrlContent.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.Extensions.AI;
+
+public class DocUrlContent : AIContent
+{
+
+    public DocUrlContent(string[] urls)
+    {
+        DocUrl = urls;
+    }
+
+    public string[] DocUrl { get; set; }
+}


### PR DESCRIPTION
新增 DocUrlContent 用于支持Microsoft.Extensions.AI.
用法:
```csharp
var messages = new List<ChatMessage>
        {
            new ChatMessage(ChatRole.System, """你是一个简历信息提取助手，请从用户提供的简历文件中提取信息"""),     
            new ChatMessage(ChatRole.User, new List<AIContent>()
            {
                new TextContent("""
                                从这份简历中提取信息, 并以能直接反序列化的JSON文本返回, 如果没有对应的信息,按 json 格式保留为空或者空数组,如果是字符串则保留为 null,如果对象上所有属性为空、空字符串或空数组,请将该对象保留为null 即可:
                                """),
                new DocUrlContent(["https://xxxxxx.pdf"]),
            })
        };
```