### PR TITLE
feat: support sparse text embeddings

### DIFF
--- a/src/Cnblogs.DashScope.Core/SparseEmbeddingItem.cs
+++ b/src/Cnblogs.DashScope.Core/SparseEmbeddingItem.cs
@@ -1,0 +1,9 @@
+namespace Cnblogs.DashScope.Core;
+
+/// <summary>
+/// Represents one element of a sparse embedding.
+/// </summary>
+/// <param name="Index">The index of the token in the vocabulary.</param>
+/// <param name="Token">The text of the token.</param>
+/// <param name="Value">The weight or importance score of the token in the input text.</param>
+public record SparseEmbeddingItem(int Index, string Token, float Value);

--- a/src/Cnblogs.DashScope.Core/TextEmbeddingItem.cs
+++ b/src/Cnblogs.DashScope.Core/TextEmbeddingItem.cs
@@ -5,4 +5,5 @@
 /// </summary>
 /// <param name="TextIndex">The correspond text's index in input array.</param>
 /// <param name="Embedding">The resulting embedding.</param>
-public record TextEmbeddingItem(int TextIndex, float[] Embedding);
+/// <param name="SparseEmbedding">The resulting sparse embedding.</param>
+public record TextEmbeddingItem(int TextIndex, float[] Embedding, List<SparseEmbeddingItem> SparseEmbedding);

--- a/test/Cnblogs.DashScope.Tests.Shared/Utils/Snapshots.TextEmbedding.cs
+++ b/test/Cnblogs.DashScope.Tests.Shared/Utils/Snapshots.TextEmbedding.cs
@@ -17,7 +17,7 @@ public static partial class Snapshots
             },
             new ModelResponse<TextEmbeddingOutput, TextEmbeddingTokenUsage>
             {
-                Output = new TextEmbeddingOutput(new List<TextEmbeddingItem> { new(0, new float[0]) }),
+                Output = new TextEmbeddingOutput(new List<TextEmbeddingItem> { new(0, new float[0], new()) }),
                 RequestId = "1773f7b2-2148-9f74-b335-b413e398a116",
                 Usage = new TextEmbeddingTokenUsage(3)
             });
@@ -33,7 +33,7 @@ public static partial class Snapshots
             },
             new ModelResponse<TextEmbeddingOutput, TextEmbeddingTokenUsage>
             {
-                Output = new TextEmbeddingOutput(new List<TextEmbeddingItem> { new(0, new float[0]) }),
+                Output = new TextEmbeddingOutput(new List<TextEmbeddingItem> { new(0, new float[0], new()) }),
                 RequestId = "1773f7b2-2148-9f74-b335-b413e398a116",
                 Usage = new TextEmbeddingTokenUsage(3)
             });


### PR DESCRIPTION
Add support sparse text embeddings in repsonse.

<img width="1247" height="599" alt="PixPin_2026-08-06_14-02-35" src="https://github.com/user-attachments/assets/bbd60a4c-48fd-4ac2-869e-4b815daa139c" />
